### PR TITLE
[Blog Fix] Fixed links for tags and categories and Title Image

### DIFF
--- a/themes/hugo-theme-massively/layouts/_default/single.html
+++ b/themes/hugo-theme-massively/layouts/_default/single.html
@@ -35,6 +35,7 @@
 													  <a href = "http://asetalias.in/blog/tags/{{ lower $elem_val }}/">{{ $elem_val }}</a>
 														{{ end }}
 														{{ end }}
+                            </p>
                             {{ .Content }}
 														<p> <b>Author:</b> {{ .Params.author}}</p>
 

--- a/themes/hugo-theme-massively/layouts/_default/single.html
+++ b/themes/hugo-theme-massively/layouts/_default/single.html
@@ -25,17 +25,16 @@
                             {{ if .Params.categories}}
 														<b>Categories:</b>
                             {{ range $elem_val := .Params.categories}}
-													  <a href = "http://asetalias.in/blog/categories/{{ $elem_val }}/">{{ $elem_val }}</a>
+													  <a href = "http://asetalias.in/blog/categories/{{ lower $elem_val }}/">{{ $elem_val }}</a>
 														{{ end }}
 														{{ end }}
 														<br>
 														{{ if .Params.tags}}
 														<b>Tags:</b>
 														{{ range $elem_val := .Params.tags}}
-													  <a href = "http://asetalias.in/blog/tags/{{ $elem_val }}/">{{ $elem_val }}</a>
+													  <a href = "http://asetalias.in/blog/tags/{{ lower $elem_val }}/">{{ $elem_val }}</a>
 														{{ end }}
 														{{ end }}
-													  </p>
                             {{ .Content }}
 														<p> <b>Author:</b> {{ .Params.author}}</p>
 

--- a/themes/hugo-theme-massively/layouts/partials/header.html
+++ b/themes/hugo-theme-massively/layouts/partials/header.html
@@ -1,4 +1,10 @@
 <!-- Header -->
+<style>
+img.responsive {
+  max-width: 100%;
+  height: auto;
+}
+</style>
 <header id="header">
-    <a href='{{ "/" | relLangURL }}' class="logo"><img src="/blog/images/logo.png" alt="ALiAS Blog" width="450px" height="180px" class ="responsive"></a>
+    <a href='{{ "/" | relLangURL }}' class="logo"><img src="/blog/images/logo.png" alt="ALiAS Blog" class ="responsive" width="450px" height="180px"></a>
 </header>

--- a/themes/hugo-theme-massively/static/assets/css/main.css
+++ b/themes/hugo-theme-massively/static/assets/css/main.css
@@ -2419,11 +2419,6 @@ img[src$='#center']
     margin-right: auto;
 }
 
-.responsive {
-	max-width: 100%;
-	height: auto;
-}
-
 .image {
 		border: 0;
 		display: inline-block;


### PR DESCRIPTION
I have tried to fix the image, it looks a little better
```
Before:
```
![Screenshot_20190602-164103](https://user-images.githubusercontent.com/30147327/58760442-8b762180-8555-11e9-8833-3b6cb858f93f.png)
```
After:
```
![Screenshot_20190602-164049](https://user-images.githubusercontent.com/30147327/58760443-8d3fe500-8555-11e9-8492-cf2bc7b346dd.png)

Also fixed tags and categories links.

Reference: [Blog-Fork](https://sc0rpi0n101.github.io/blog/)